### PR TITLE
fix supervisor.memcached.conf

### DIFF
--- a/lims2/supervisor.memcached.conf
+++ b/lims2/supervisor.memcached.conf
@@ -1,2 +1,2 @@
 [program:memcached]
-command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 10240 -p 11211
+command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 1024 -p 11211

--- a/mall-old/supervisor.memcached.conf
+++ b/mall-old/supervisor.memcached.conf
@@ -1,2 +1,2 @@
 [program:memcached]
-command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 10240 -p 11211
+command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 1024 -p 11211

--- a/qf-dev/supervisor.memcached.conf
+++ b/qf-dev/supervisor.memcached.conf
@@ -1,2 +1,2 @@
 [program:memcached]
-command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 10240 -p 11211
+command=/usr/bin/memcached -m 2000 -u nobody -l 0.0.0.0 -c 1024 -p 11211


### PR DESCRIPTION
并发值过高memcached无法正常启动
修改为默认的1024后可正常启动
