### PR TITLE
Generate `/etc/cron.d/lims2`.

### DIFF
--- a/lims2/Dockerfile
+++ b/lims2/Dockerfile
@@ -106,5 +106,10 @@ EXPOSE 9000
 EXPOSE 80
 EXPOSE 22
 
-ENTRYPOINT ["/usr/bin/supervisord"]
-CMD ["-c", "/etc/supervisor/supervisord.conf"]
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ADD entrypoint.d /entrypoint.d
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/lims2/entrypoint.d/get-cron.sh
+++ b/lims2/entrypoint.d/get-cron.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+(
+	sleep 3
+	SITE_ID=$SITE_ID LAB_ID=$LAB_ID php /usr/local/share/lims2/cli/get_cron.php -u genee > /etc/cron.d/lims2
+) &

--- a/lims2/entrypoint.sh
+++ b/lims2/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for ep in /entrypoint.d/* ; do
+	[ ! -x "$ep" ] || eval "$ep"
+done
+exec "$@"


### PR DESCRIPTION
get_cron.php must be run after nginx started.  Currently wait 3 secs for supervisord (hack).
